### PR TITLE
throw the proper exception in create() when called synchronously with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Before making it available to the browser as JSON for use in a `moog.mirror` cal
 
 ## Changelog
 
+0.2.4: throw the proper exception when synchronously creating a type that extends an undefined type. (Previously an exception was thrown, but it wasn't informative. It was an accidental benefit of trying to invoke a nonexistent callback.)
+
 0.2.3: exceptions thrown for attempts to synchronously create types with asynchronous beforeConstruct/construct/afterConstruct methods now include the correct name of the type or ancestor type that requires the call to be asynchronous.
 
 0.2.2: if `afterConstruct` expects a callback, calling `create` synchronously should throw an error. This is a bug fix, so no minor version bump is required.

--- a/index.js
+++ b/index.js
@@ -159,7 +159,10 @@
               // the default implementation
               next = self.define(nextName, undefined, current);
             } catch (e) {
-              return callback(e);
+              if (callback) {
+                return callback(e);
+              }
+              throw e;
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moog",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Moog provides powerful module subclassing.",
   "main": "index.js",
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -202,7 +202,7 @@ describe('moog', function() {
       });
     });
 
-    it('should be able to create a subclass with expected default option behavior', function(done) {
+    it('should be able to create a subclass with expected default option behavior (async)', function(done) {
       var moog = require('../index.js')({});
 
       moog.define('baseClass', {
@@ -226,6 +226,60 @@ describe('moog', function() {
         assert(myObject._options.color === 'red');
         return done();
       });
+    });
+
+    it('should be able to create a subclass with expected default option behavior (sync)', function() {
+      var moog = require('../index.js')({});
+
+      moog.define('baseClass', {
+        color: 'blue',
+        construct: function(self, options) {
+          self._options = options;
+        }
+      });
+
+      moog.define('subClass', {
+        color: 'red',
+        extend: 'baseClass'
+      });
+
+      var myObject = moog.create('subClass', {});
+      assert(myObject);
+      assert(myObject._options.color === 'red');
+    });
+
+    it('should report an error gracefully if subclass to be extended does not exist (async)', function(done) {
+      var moog = require('../index.js')({});
+
+      // base class does not actually exist
+      moog.define('subClass', {
+        color: 'red',
+        extend: 'baseClass'
+      });
+
+      moog.create('subClass', {}, function(err, myObject) {
+        assert(err);
+        return done();
+      });
+    });
+
+    it('should throw an exception gracefully if subclass to be extended does not exist (sync)', function() {
+      var moog = require('../index.js')({});
+
+      // base class does not actually exist
+      moog.define('subClass', {
+        color: 'red',
+        extend: 'baseClass'
+      });
+
+      var exception;
+      try {
+        var myObject = moog.create('subClass', {});
+      } catch (e) {
+        exception = e;
+      }
+      assert(exception);
+      assert(exception.toString().match(/baseClass/));
     });
 
     it('should be able to `extend` a subclass into yet another subclass', function(done) {


### PR DESCRIPTION
… a nonexistent parent type

@jth- pls peep
